### PR TITLE
PRODCAT-343 stop the logger from exploding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests-futures==0.9.5
 mock
+flake8==3.3.0

--- a/restapi_logging_handler/loggly_handler.py
+++ b/restapi_logging_handler/loggly_handler.py
@@ -8,7 +8,10 @@ from functools import partial
 
 import requests
 
-from restapi_logging_handler.restapi_logging_handler import RestApiHandler
+from restapi_logging_handler.restapi_logging_handler import (
+    RestApiHandler,
+    serialize,
+)
 
 
 def setInterval(interval):
@@ -109,7 +112,7 @@ class LogglyHandler(RestApiHandler):
         This preps the payload to be formatted in whatever content-type is
         expected from the RESTful API.
         """
-        return json.dumps(self._getPayload(record))
+        return json.dumps(self._getPayload(record), default=serialize)
 
     def _getPayload(self, record):
         """

--- a/restapi_logging_handler/restapi_logging_handler.py
+++ b/restapi_logging_handler/restapi_logging_handler.py
@@ -82,7 +82,27 @@ def serialize(obj):
         serial = str(obj)
         return serial
 
-    return obj.__dict__
+    try:
+        return obj.__dict__
+    except AttributeError:
+        return str(obj)
+    except Exception as e:
+        strval = 'unknown obj'
+        exceptval = 'unknown err'
+        try:
+            strval = str(obj)
+            exceptval = repr(e)
+        except:
+            pass
+        return 'json fail {} {}'.format(exceptval, strval)
+
+
+# test
+def simple_json(obj):
+    try:
+        return json.dumps(obj, default=serialize)
+    except:
+        return "cannot serialize {}".format(type(obj))
 
 
 class RestApiHandler(logging.Handler):
@@ -143,6 +163,7 @@ class RestApiHandler(logging.Handler):
         """
         The data that will be sent to the RESTful API
         """
+
         try:
             # top level payload items
             payload = {
@@ -158,7 +179,7 @@ class RestApiHandler(logging.Handler):
 
             # everything else goes in details
             payload['details'] = {
-                k: v for (k, v) in record.__dict__.items()
+                k: simple_json(v) for (k, v) in record.__dict__.items()
                 if k not in self.detail_ignore_set
                 }
 

--- a/restapi_logging_handler/restapi_logging_handler.py
+++ b/restapi_logging_handler/restapi_logging_handler.py
@@ -1,3 +1,5 @@
+import datetime
+import uuid
 import logging
 import json
 import traceback
@@ -68,6 +70,19 @@ TOP_KEYS = {
     'levelname',
     'name',
 }
+
+
+def serialize(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, datetime.datetime):
+        serial = obj.isoformat(sep='T')
+        return serial
+
+    if isinstance(obj, uuid.UUID):
+        serial = str(obj)
+        return serial
+
+    return obj.__dict__
 
 
 class RestApiHandler(logging.Handler):
@@ -174,9 +189,11 @@ class RestApiHandler(logging.Handler):
         returns: a tuple of the data and the http content-type
         """
         payload = self._getPayload(record)
+        json_data = json.dumps(payload, default=serialize)
+
         return {
-            'json': (json.dumps(payload), 'application/json')
-        }.get(self.content_type, (json.dumps(payload), 'text/plain'))
+            'json': (json_data, 'application/json')
+        }.get(self.content_type, (json_data, 'text/plain'))
 
     def emit(self, record):
         """

--- a/restapi_logging_handler/tests/test_restapi_logging_handler.py
+++ b/restapi_logging_handler/tests/test_restapi_logging_handler.py
@@ -89,7 +89,7 @@ class TestRestApiHandler(TestCase):
 
         self.assertEquals(
             details,
-            {'this': 1, 'that': None}
+            {'this': '1', 'that': 'null'}
         )
 
     def test_logging_uuid(self):
@@ -98,7 +98,7 @@ class TestRestApiHandler(TestCase):
 
         random_id = uuid.uuid4()
 
-        log.info('test message', extra={'this': random_id, 'that': None})
+        log.info('test message', extra={'this': random_id})
 
         self.session.return_value.post.assert_called_once()
 
@@ -109,7 +109,7 @@ class TestRestApiHandler(TestCase):
 
         self.assertEquals(
             details,
-            {'this': str(random_id), 'that': None}
+            {'this': '"{}"'.format(str(random_id))}
         )
 
     def test_logging_datetime(self):
@@ -118,7 +118,7 @@ class TestRestApiHandler(TestCase):
 
         random_date = datetime.datetime.utcnow()
 
-        log.info('test message', extra={'this': random_date, 'that': None})
+        log.info('test message', extra={'this': random_date})
 
         self.session.return_value.post.assert_called_once()
 
@@ -129,7 +129,7 @@ class TestRestApiHandler(TestCase):
 
         self.assertEquals(
             details,
-            {'this': random_date.isoformat(sep='T'), 'that': None}
+            {'this': '"{}"'.format(random_date.isoformat(sep='T'))}
         )
 
     def test_logging_thing(self):
@@ -152,10 +152,13 @@ class TestRestApiHandler(TestCase):
 
         details = payload.pop('details')
 
+        thing = details.pop('this')
+        self.assertEquals(json.loads(thing),
+                          {"thing1": "Fred", "thing2": "Jerry"})
+
         self.assertEquals(
             details,
-            {'this': {'thing1': 'Fred', 'thing2': 'Jerry'},
-             'that': None}
+            {'that': 'null'}
         )
 
     def test_ignored_record_keys(self):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except (IOError, ImportError):
 
 setup(
     name='restapi-logging-handler',
-    version='0.2.3',
+    version='0.2.4',
     description='A handler for the python logging module that sends logs \
         through any REST-ful API. With threading and Loggly support that \
         handles batch POSTS.',
@@ -21,9 +21,11 @@ setup(
     author_email='r.j.gilligan@nrg.com, '
                  'ethan.mccreadie@nrg.com, '
                  'mike.reppy@nrg.com',
-    url='https://github.com/narwhaljames/restapi-logging-handler.git',
-    download_url='https://github.com/narwhaljames/'
-                 'restapi-logging-handler/tarball/0.2.3',
+    url='https://github.com/EnergyPlus/restapi-logging-handler.git',
+    download_url=(
+        'https://github.com/EnergyPlus/restapi-logging-handler.git/'
+        'tarball/0.2.4'
+    ),
     keywords=['rest', 'api', 'logging', 'handler', 'loggly'],
     classifiers=[],
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except (IOError, ImportError):
 
 setup(
     name='restapi-logging-handler',
-    version='0.2.4',
+    version='0.2.7',
     description='A handler for the python logging module that sends logs \
         through any REST-ful API. With threading and Loggly support that \
         handles batch POSTS.',
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/EnergyPlus/restapi-logging-handler.git',
     download_url=(
         'https://github.com/EnergyPlus/restapi-logging-handler.git/'
-        'tarball/0.2.4'
+        'tarball/0.2.7'
     ),
     keywords=['rest', 'api', 'logging', 'handler', 'loggly'],
     classifiers=[],


### PR DESCRIPTION
If the extra dict items passed to the logger are not serializable, the logging framework explodes, causing a server error.

This is one approach, I don't exactly love it, but it fixes the immediate need in the product api whereby a 404 passes the wsgi request to the logger and that is not serializable.

It also establishes a new version which can be installed to the internal pypi server so it's easier to reference in our projects.

Longer term we should reconcile with RJ or change the name for internal use so we don't conflict with public pypi.